### PR TITLE
Csiro/password reset

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -53,3 +53,14 @@ resource "aws_lambda_permission" "S3deidentifyFiles" {
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.dataportal-bucket.arn
 }
+
+#
+# passwordResetEmail Lambda Function
+#
+resource "aws_lambda_permission" "cognitoPasswordResetEmail" {
+  statement_id = "SBeaconBackendAllowCognitoPasswordResetInvoke"
+  action = "lambda:InvokeFunction"
+  function_name = module.lambda-passwordResetEmail.lambda_function_arn
+  principal = "cognito-idp.amazonaws.com"
+  source_arn = var.cognito-user-pool-arn
+}

--- a/lambda/passwordResetEmail/lambda_function.py
+++ b/lambda/passwordResetEmail/lambda_function.py
@@ -1,0 +1,56 @@
+import json
+
+import boto3
+from markupsafe import escape
+
+from shared.utils import ENV_SES
+
+SES_SOURCE_EMAIL = ENV_SES.SES_SOURCE_EMAIL
+SES_CONFIG_SET_NAME = ENV_SES.SES_CONFIG_SET_NAME
+ses_client = boto3.client("ses")
+
+
+def lambda_handler(event, _):
+    print("Event Received: {}".format(json.dumps(event)))
+    if event["triggerSource"] == "CustomMessage_ForgotPassword":
+        first_name = event["request"]["userAttributes"]["given_name"]
+        last_name = event["request"]["userAttributes"]["family_name"]
+        reset_code = event["request"]["codeParameter"]
+        subject = "Data Portal Password Reset"
+        body_html = f"""
+        <html>
+          <head>
+            <style>
+              body {{
+                font-family: Arial, sans-serif;
+                color: #333;
+              }}
+              .container {{
+                max-width: 600px;
+                margin: auto;
+                padding: 20px;
+                border: 1px solid #ddd;
+                border-radius: 5px;
+                background-color: #f9f9f9;
+              }}
+              h1 {{
+                color: #33548e;
+              }}
+              p {{
+                line-height: 1.6;
+              }}
+            </style>
+          </head>
+          <body>
+            <div class="container">
+              <h1>Hello {escape(first_name)} {escape(last_name)},</h1>
+              <p>Please use the code below to reset your password.</p>
+              <p>Reset Code: <strong>{reset_code}</strong></p>
+              <p>Thank you,<br>Data Portal</p>
+            </div>
+          </body>
+        </html>
+        """
+        event["response"]["emailSubject"] = subject
+        event["response"]["emailMessage"] = body_html
+        return event

--- a/lambda/passwordResetEmail/lambda_function.py
+++ b/lambda/passwordResetEmail/lambda_function.py
@@ -1,13 +1,6 @@
 import json
 
-import boto3
 from markupsafe import escape
-
-from shared.utils import ENV_SES
-
-SES_SOURCE_EMAIL = ENV_SES.SES_SOURCE_EMAIL
-SES_CONFIG_SET_NAME = ENV_SES.SES_CONFIG_SET_NAME
-ses_client = boto3.client("ses")
 
 
 def lambda_handler(event, _):

--- a/main.tf
+++ b/main.tf
@@ -771,6 +771,34 @@ module "lambda-getProjects" {
 }
 
 #
+# password reset email lambda function
+#
+module "lambda-passwordResetEmail" {
+  source = "terraform-aws-modules/lambda/aws"
+  
+  function_name = "sbeacon-backend-passwordResetEmail"
+  description = "Sends a custom password reset email to the user"
+  runtime = "python3.12"
+  handler = "lambda_function.lambda_handler"
+  memory_size = 512
+  timeout = 24
+  source_path = "${path.module}/lambda/passwordResetEmail"
+  
+  tags = var.common-tags
+  
+  environment_variables = merge(
+    local.sbeacon_variables,
+    { SES_SOURCE_EMAIL = var.ses-source-email },
+    { SES_CONFIG_SET_NAME = aws_ses_configuration_set.ses_feedback_config.name },
+  )
+
+  layers = [
+    local.python_libraries_layer,
+    local.python_modules_layer,
+  ]
+}
+
+#
 # email notification Lambda function
 #
 module "lambda-logEmailDelivery" {

--- a/main.tf
+++ b/main.tf
@@ -786,15 +786,8 @@ module "lambda-passwordResetEmail" {
   
   tags = var.common-tags
   
-  environment_variables = merge(
-    local.sbeacon_variables,
-    { SES_SOURCE_EMAIL = var.ses-source-email },
-    { SES_CONFIG_SET_NAME = aws_ses_configuration_set.ses_feedback_config.name },
-  )
-
   layers = [
     local.python_libraries_layer,
-    local.python_modules_layer,
   ]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,17 @@ output "data-portal-bucket-arn" {
   value       = aws_s3_bucket.dataportal-bucket.arn
   description = "S3 bucket arn for the data portal."
 }
+
+output "password-reset-email-lambda-arn" {
+  value = module.lambda-passwordResetEmail.lambda_function_arn
+  description = "ARN for the password reset email lambda function"
+}
+
+output "ses-source-email-arn" {
+  value = data.aws_ses_email_identity.ses_source_email.arn
+  description = "ARN for the identity from which to send SES emails"
+}
+
+output "ses-configuration-set" {
+  value = aws_ses_configuration_set.ses_feedback_config.name
+}

--- a/shared_resources/python-modules/python/shared/utils/__init__.py
+++ b/shared_resources/python-modules/python/shared/utils/__init__.py
@@ -9,6 +9,7 @@ from .lambda_utils import (
     ENV_DYNAMO,
     ENV_CONFIG,
     ENV_COGNITO,
+    ENV_SES,
     make_temp_file,
     clear_tmp,
 )


### PR DESCRIPTION
`lambda.tf` - The block added here grants the cognito pool (gaspi-user-pool, located in `cognito/cognito.tf`) to start the passwordResetEmail lambda function

`lambda/passwordResetEmail/lambda_function.py` - Implementation of the email. Whenever a password reset request is made. Cognito will start this. First, the lambda function checks whether it was triggered by a password reset. If so, it creates the custom email and returns it. Cognito will receive this response and send an email to the user that triggered it.

`main.tf` - This block defines the lambda function for custom emails

`outputs.tf` - The cognito user pool in the GASPI repository needs to know the ARN for the lambda function, the SES identity to send from, and the configuration set to use (our configuration set is used to log the delivery status of emails sent out - see `lambda/logEmailDelivery` and the configuration set in `ses.tf`). They are provided as outputs here so they can be accessed from outside the sbeacon module.

`__init__.py` - This change is not relevant to the feature