### PR TITLE
DEV: Enhance report generation with report ID

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -768,3 +768,15 @@ data "aws_iam_policy_document" "dataportal-locks-access" {
     ]
   }
 }
+
+# generateReports lambda access
+data "aws_iam_policy_document" "lambda-generateReports" {
+  statement {
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.dataportal-bucket.arn}/projects/*/clinical-workflows/*/reports/*",
+    ]
+  }
+}

--- a/lambda/dataPortal/clinic_functions.py
+++ b/lambda/dataPortal/clinic_functions.py
@@ -430,6 +430,9 @@ def generate_report(event, context):
             for k, v in job.reference_versions.as_dict().items()
             if k.endswith("_version")
         }
+        request_id = event["requestContext"]["requestId"]
+        vcf = job.input_vcf
+        job_name = job.job_name
     except ProjectUsers.DoesNotExist:
         raise PortalError(404, "User not found in project")
     except ClinicJobs.DoesNotExist:
@@ -445,12 +448,24 @@ def generate_report(event, context):
         if HUB_NAME == "RSCM":
             if not variants:
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "kind": "neg",
                     "versions": versions,
                 }
             else:
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "kind": "pos",
                     "variants": variants,
@@ -488,6 +503,12 @@ def generate_report(event, context):
                         }
 
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "phenotype": phenotype,
                     "alleles": ",".join((variants[0]["Alleles"])),
@@ -544,6 +565,12 @@ def generate_report(event, context):
                         "genotype": "-",
                     }
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "slco1b1": slco1b1,
                     "apoe": apoe,
@@ -562,6 +589,12 @@ def generate_report(event, context):
                 }
         elif HUB_NAME == "RSIGNG":
             payload = {
+                "report_id": request_id,
+                "job_id": job_id,
+                "job_name": job_name,
+                "reporter_sub": sub,
+                "project": project,
+                "vcf": vcf,
                 "lab": HUB_NAME,
                 "variants": variants,
                 "versions": versions,
@@ -574,6 +607,12 @@ def generate_report(event, context):
         elif HUB_NAME == "RSSARDJITO":
             if not variants:
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "kind": "neg",
                     "lang": body["lang"],
@@ -582,6 +621,12 @@ def generate_report(event, context):
                 }
             else:
                 payload = {
+                    "report_id": request_id,
+                    "job_id": job_id,
+                    "job_name": job_name,
+                    "reporter_sub": sub,
+                    "project": project,
+                    "vcf": vcf,
                     "lab": HUB_NAME,
                     "kind": "pos",
                     "lang": body["lang"],

--- a/lambda/generateReports/igng/generate.py
+++ b/lambda/generateReports/igng/generate.py
@@ -13,7 +13,13 @@ except:
 
 
 def generate(
-    *, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None
 ):
     # Generate the first stage of the report
     table_pdf = generate_pos_stage_1(variants=variants)
@@ -25,7 +31,7 @@ def generate(
 
     # Generate the third stage of the report
     report = generate_pos_stage_3(
-        table_pdf, annots_pdf, pii_name=pii_name, pii_dob=pii_dob
+        table_pdf, annots_pdf, pii_name=pii_name, pii_dob=pii_dob, report_id=report_id
     )
 
     os.remove(table_pdf)
@@ -35,6 +41,8 @@ def generate(
 
 
 if __name__ == "__main__":
+    import uuid
+
     # Example usage - for testing includes made up data
     generate(
         pii_name="John Doe",
@@ -92,4 +100,5 @@ if __name__ == "__main__":
                 "Phenotype Categories": "Efficacy",
             },
         ],
+        report_id=str(uuid.uuid4()),
     )

--- a/lambda/generateReports/igng/pos_stage_3.py
+++ b/lambda/generateReports/igng/pos_stage_3.py
@@ -3,13 +3,13 @@ import uuid
 from datetime import datetime
 
 from PyPDF2 import PdfReader, PdfWriter
-from reportlab.lib.pagesizes import letter
+from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
 
 
-def _create_annotations(filename, pages, page_num_pos):
-    c = canvas.Canvas(filename, pagesize=letter)
+def _create_annotations(filename, pages, page_num_pos, report_id=None):
+    c = canvas.Canvas(filename, pagesize=A4)
     form = c.acroForm
 
     text_boxes = [
@@ -47,6 +47,9 @@ def _create_annotations(filename, pages, page_num_pos):
         c.setFont("Helvetica", 11)
         c.setFillColor(colors.HexColor("#828282"))
         c.drawString(x, y, f"Halaman  {p+1} dari {pages}")
+        x, y, fs, text = (5, 830, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
 
         for n, (x, y, w, fs) in enumerate(text_boxes):
             form.textfield(
@@ -80,6 +83,7 @@ def generate(
     pii_name=None,
     pii_dob=None,
     pii_gender=None,
+    report_id=None,
 ):
     # x, y, fs, text
     page_num_pos = (500, 50)
@@ -90,7 +94,7 @@ def generate(
 
     total_pages = len(pdf_body.pages) + len(pdf_table.pages)
 
-    _create_annotations(output_pdf_path, total_pages, page_num_pos)
+    _create_annotations(output_pdf_path, total_pages, page_num_pos, report_id)
 
     writer = PdfWriter()
     pages = []

--- a/lambda/generateReports/lambda_function.py
+++ b/lambda/generateReports/lambda_function.py
@@ -1,6 +1,7 @@
 import os
 import base64
 import json
+from datetime import datetime
 
 import boto3
 
@@ -23,6 +24,7 @@ def lambda_handler(event, context):
     report_id = event["report_id"]
     project = event["project"]
     job_id = event["job_id"]
+    event["timestamp"] = str(datetime.now())
 
     # RSCM
     match event["lab"]:

--- a/lambda/generateReports/lambda_function.py
+++ b/lambda/generateReports/lambda_function.py
@@ -2,6 +2,12 @@ import os
 import base64
 import json
 
+import boto3
+
+
+s3_client = boto3.client("s3")
+DPORTAL_BUCKET = os.environ.get("DPORTAL_BUCKET")
+
 
 def lambda_handler(event, context):
     print("Backend Event Received: ", event)
@@ -14,6 +20,9 @@ def lambda_handler(event, context):
     }
 
     versions = {**json.load(open("versions.json")), **event["versions"]}
+    report_id = event["report_id"]
+    project = event["project"]
+    job_id = event["job_id"]
 
     # RSCM
     match event["lab"]:
@@ -21,16 +30,20 @@ def lambda_handler(event, context):
             from rscm import generate_neg, generate_pos
 
             if event["kind"] == "neg":
-                res = generate_neg(**data, versions=versions)
+                res = generate_neg(**data, versions=versions, report_id=report_id)
             elif event["kind"] == "pos":
                 assert len(event["variants"]) > 0, "Variants not provided"
                 variants = event.get("variants", [])
-                res = generate_pos(**data, variants=variants, versions=versions)
+                res = generate_pos(
+                    **data, variants=variants, versions=versions, report_id=report_id
+                )
         case "RSIGNG":
             from igng import generate
 
             variants = event["variants"]
-            res = generate(**data, variants=variants, versions=versions)
+            res = generate(
+                **data, variants=variants, versions=versions, report_id=report_id
+            )
         case "RSSARDJITO":
             from rssardjito import get_report_generator
 
@@ -39,16 +52,22 @@ def lambda_handler(event, context):
                 event["kind"], event["mode"], event["lang"]
             )
             if event["kind"] == "pos":
-                res = generator(**data, variants=variants, versions=versions)
+                res = generator(
+                    **data, variants=variants, versions=versions, report_id=report_id
+                )
             else:
-                res = generator(**data, versions=versions)
+                res = generator(**data, versions=versions, report_id=report_id)
         case "RSPON":
             from rspon import generate
 
             phenotype = event["phenotype"]
             alleles = event["alleles"]
             res = generate(
-                **data, phenotype=phenotype, alleles=alleles, versions=versions
+                **data,
+                phenotype=phenotype,
+                alleles=alleles,
+                versions=versions,
+                report_id=report_id,
             )
         case "RSJPD":
             from rsjpd import generate
@@ -58,7 +77,7 @@ def lambda_handler(event, context):
                 "apoe": event.get("apoe", None),
                 "slco1b1": event.get("slco1b1", None),
             }
-            res = generate(**data, versions=versions)
+            res = generate(**data, versions=versions, report_id=report_id)
         case _:
             return {"statusCode": 400, "body": "Invalid lab or not implemented"}
 
@@ -67,6 +86,13 @@ def lambda_handler(event, context):
 
     encoded_content = base64.b64encode(binary_content).decode("utf-8")
     os.remove(res)
+
+    # Save the report metadata to S3
+    s3_client.put_object(
+        Bucket=DPORTAL_BUCKET,
+        Key=f"projects/{project}/clinical-workflows/{job_id}/reports/{report_id}.json",
+        Body=json.dumps(event),
+    )
 
     return {
         "statusCode": 200,

--- a/lambda/generateReports/rscm/neg.py
+++ b/lambda/generateReports/rscm/neg.py
@@ -20,6 +20,7 @@ def _create_annotations(
     footer_dob_pos,
     filename,
     versions,
+    report_id,
 ):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
@@ -121,6 +122,9 @@ def _create_annotations(
     )
 
     for n in range(3):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         # footer name
         x, y, fs, text = footer_name_pos
         form.textfield(
@@ -159,15 +163,15 @@ def _create_annotations(
         if n == 2:
             versions_pos = [
                 # left col
-                (180, 570+15, 11, versions["snp_eff_version"]),
-                (180, 556+15, 11, versions["snp_sift_version"]),
-                (180, 542+15, 11, versions["clinvar_version"]),
-                (180, 528+15, 11, versions["omim_version"]),
+                (180, 570 + 15, 11, versions["snp_eff_version"]),
+                (180, 556 + 15, 11, versions["snp_sift_version"]),
+                (180, 542 + 15, 11, versions["clinvar_version"]),
+                (180, 528 + 15, 11, versions["omim_version"]),
                 # right col
-                (450-20, 570+15, 11, versions["gnomad_version"]),
-                (450-20, 556+15, 11, versions["dbsnp_version"]),
-                (450-20, 542+15, 11, versions["sift_version"]),
-                (450-20, 528+15, 11, versions["polyphen2_version"]),
+                (450 - 20, 570 + 15, 11, versions["gnomad_version"]),
+                (450 - 20, 556 + 15, 11, versions["dbsnp_version"]),
+                (450 - 20, 542 + 15, 11, versions["sift_version"]),
+                (450 - 20, 528 + 15, 11, versions["polyphen2_version"]),
             ]
             for pos in versions_pos:
                 x, y, fs, text = pos
@@ -199,7 +203,9 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_pdf_path = "/tmp/annotations.pdf"
     input_pdf_path = f"{module_dir}/neg.pdf"
@@ -225,6 +231,7 @@ def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
         footer_dob_pos,
         output_pdf_path,
         versions,
+        report_id,
     )
     output_file_name = f"/tmp/{str(uuid.uuid4())}.pdf"
     _overlay_pdf_with_annotations(output_pdf_path, input_pdf_path, output_file_name)
@@ -252,4 +259,5 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        report_id=str(uuid.uuid4()),
     )

--- a/lambda/generateReports/rscm/pos.py
+++ b/lambda/generateReports/rscm/pos.py
@@ -13,7 +13,13 @@ except:
 
 
 def generate(
-    *, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None
 ):
     # Generate the first stage of the report
     summary_pdf, results_pdf = generate_pos_stage_1(variants=variants)
@@ -25,7 +31,12 @@ def generate(
 
     # Generate the third stage of the report
     report = generate_pos_stage_3(
-        summary_pdf, results_pdf, annots_pdf, pii_name=pii_name, pii_dob=pii_dob
+        summary_pdf,
+        results_pdf,
+        annots_pdf,
+        pii_name=pii_name,
+        pii_dob=pii_dob,
+        report_id=report_id,
     )
 
     os.remove(summary_pdf)
@@ -36,6 +47,8 @@ def generate(
 
 
 if __name__ == "__main__":
+    import uuid
+
     # Example usage - for testing includes made up data
     generate(
         pii_name="John Doe",
@@ -98,4 +111,5 @@ if __name__ == "__main__":
                 "conditions": "rosuvastatin response - Metabolism/PK",
             },
         ],
+        report_id=str(uuid.uuid4()),
     )

--- a/lambda/generateReports/rscm/pos_stage_3.py
+++ b/lambda/generateReports/rscm/pos_stage_3.py
@@ -7,11 +7,16 @@ from reportlab.pdfgen import canvas
 from reportlab.lib import colors
 
 
-def _create_annotations(filename, pages, footer_name_pos, footer_dob_pos, page_num_pos):
+def _create_annotations(
+    filename, pages, footer_name_pos, footer_dob_pos, page_num_pos, report_id=None
+):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
 
     for p in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         # footer name
         x, y, fs, text = footer_name_pos
         form.textfield(
@@ -58,12 +63,7 @@ def _create_annotations(filename, pages, footer_name_pos, footer_dob_pos, page_n
 
 
 def generate(
-    summary_pdf,
-    results_pdf,
-    annots_pdf,
-    *,
-    pii_name=None,
-    pii_dob=None,
+    summary_pdf, results_pdf, annots_pdf, *, pii_name=None, pii_dob=None, report_id=None
 ):
     # x, y, fs, text
     footer_name_pos = (146, 48, 12, pii_name)
@@ -78,7 +78,12 @@ def generate(
     total_pages = len(pdf_int.pages) + len(pdf_results.pages) + len(pdf_summary.pages)
 
     _create_annotations(
-        output_pdf_path, total_pages, footer_name_pos, footer_dob_pos, page_num_pos
+        output_pdf_path,
+        total_pages,
+        footer_name_pos,
+        footer_dob_pos,
+        page_num_pos,
+        report_id,
     )
 
     writer = PdfWriter()

--- a/lambda/generateReports/rsjpd/generate.py
+++ b/lambda/generateReports/rsjpd/generate.py
@@ -3,13 +3,24 @@ import uuid
 
 from PyPDF2 import PdfReader, PdfWriter
 from pathlib import Path
-from reportlab.lib.pagesizes import letter
+from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
 
 
-def _create_annotations(filename, slco1b1, apoe, pharmcat_version, pharmgkb_version, lookup_version):
-    c = canvas.Canvas(filename, pagesize=letter)
+def _create_annotations(
+    filename,
+    slco1b1,
+    apoe,
+    pharmcat_version,
+    pharmgkb_version,
+    lookup_version,
+    report_id,
+):
+    c = canvas.Canvas(filename, pagesize=A4)
+    x, y, fs, text = (5, 830, 12, report_id)
+    c.setFont("Helvetica", fs)
+    c.drawString(x, y, text)
     c.showPage()
     form = c.acroForm
 
@@ -139,6 +150,9 @@ def _create_annotations(filename, slco1b1, apoe, pharmcat_version, pharmgkb_vers
         (57, 25, 470, 200, 12, "", 0),
     ]
 
+    x, y, fs, text = (5, 830, 12, report_id)
+    c.setFont("Helvetica", fs)
+    c.drawString(x, y, text)
     for n, pos in enumerate(_text_field_positions_page_1):
         x, y, w, h, fs, text, flags = pos
         c.setFont("Helvetica", fs)
@@ -157,6 +171,7 @@ def _create_annotations(filename, slco1b1, apoe, pharmcat_version, pharmgkb_vers
             forceBorder=False,
             fieldFlags=flags,
         )
+
     for n, pos in enumerate(_checkbox_positions_page_1):
         x, y, fs, text, flags = pos
         c.setFont("Helvetica", fs)
@@ -177,6 +192,9 @@ def _create_annotations(filename, slco1b1, apoe, pharmcat_version, pharmgkb_vers
 
     c.showPage()
 
+    x, y, fs, text = (5, 830, 12, report_id)
+    c.setFont("Helvetica", fs)
+    c.drawString(x, y, text)
     for n, pos in enumerate(_text_field_positions_page_2):
         x, y, w, h, fs, text, flags = pos
         c.setFont("Helvetica", fs)
@@ -196,6 +214,10 @@ def _create_annotations(filename, slco1b1, apoe, pharmcat_version, pharmgkb_vers
             fieldFlags=flags,
         )
     c.showPage()
+
+    x, y, fs, text = (5, 830, 12, report_id)
+    c.setFont("Helvetica", fs)
+    c.drawString(x, y, text)
     for n, pos in enumerate(_text_field_positions_page_3):
         x, y, w, h, fs, text, flags = pos
         c.setFont("Helvetica", fs)
@@ -251,10 +273,19 @@ def generate(
     slco1b1=None,
     apoe=None,
     versions=None,
+    report_id=None,
 ):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations("/tmp/annotations.pdf", slco1b1, apoe, versions["pharmcat_version"], versions["pharmgkb_version"], versions["lookup_version"])
+    _create_annotations(
+        "/tmp/annotations.pdf",
+        slco1b1,
+        apoe,
+        versions["pharmcat_version"],
+        versions["pharmgkb_version"],
+        versions["lookup_version"],
+        report_id,
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/template.pdf",
@@ -282,5 +313,6 @@ if __name__ == "__main__":
             "pharmgkb_version": "2025-03-07-16-38",
             "lookup_version": "2025-03-07-16-38",
         },
+        "report_id": str(uuid.uuid4()),
     }
     generate(**payload)

--- a/lambda/generateReports/rspon/generate.py
+++ b/lambda/generateReports/rspon/generate.py
@@ -19,6 +19,7 @@ def _create_annotations(
     phenotype,
     pharmcat_version,
     pharmgkb_version,
+    report_id,
 ):
     YT = 695
     # x, y, w, h, flags, text
@@ -68,6 +69,9 @@ def _create_annotations(
         [pg_1_text_fields, pg_2_text_fields, pg_3_text_fields],
         [pg_1_text_boxes, pg_2_text_boxes, pg_3_text_boxes],
     ):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, (x, y, w, h, flags, text) in enumerate(common_text_fields):
             form.textfield(
                 name=f"header_{n}",
@@ -138,6 +142,7 @@ def generate(
     phenotype=None,
     alleles=None,
     versions=None,
+    report_id=None,
 ):
     module_dir = Path(__file__).parent
     kind = "".join([x[0] for x in phenotype.split(" ")])
@@ -156,6 +161,7 @@ def generate(
         phenotype,
         versions["pharmcat_version"],
         versions["pharmgkb_version"],
+        report_id,
     )
     _overlay_pdf_with_annotations(annotated, template, output_file_name)
     os.remove(annotated)
@@ -187,4 +193,5 @@ if __name__ == "__main__":
         phenotype=phenotype,
         alleles=alleles,
         versions=versions,
+        report_id=str(uuid.uuid4()),
     )

--- a/lambda/generateReports/rssardjito/crd/en_crd_neg.py
+++ b/lambda/generateReports/rssardjito/crd/en_crd_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/EN_Genome Report_No Finding_CRD.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/crd/en_crd_pos.py
+++ b/lambda/generateReports/rssardjito/crd/en_crd_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -239,7 +242,7 @@ def _overlay_template_with_table(src, dest, output):
 
 def _create_annotations(
     filename,
-    versions,    
+    versions,
 ):
     _text_field_positions_page_1 = [
         # Results Interpretation
@@ -339,7 +342,15 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None):
+def generate(
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
+):
     header_rows = [
         [
             "Gene/ Transcript",
@@ -402,7 +413,7 @@ def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, ver
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -480,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/lambda/generateReports/rssardjito/crd/id_crd_neg.py
+++ b/lambda/generateReports/rssardjito/crd/id_crd_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/ID_Genome Report_No Finding_CRD.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/crd/id_crd_pos.py
+++ b/lambda/generateReports/rssardjito/crd/id_crd_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -340,7 +343,13 @@ def _overlay_pdf_with_annotations(src, dest, output):
 
 
 def generate(
-    *, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
 ):
     header_rows = [
         [
@@ -404,7 +413,7 @@ def generate(
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -482,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/lambda/generateReports/rssardjito/generic/en_gen_neg.py
+++ b/lambda/generateReports/rssardjito/generic/en_gen_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/EN_Genome Report_No Finding-GENERIC.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/generic/en_gen_pos.py
+++ b/lambda/generateReports/rssardjito/generic/en_gen_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -340,7 +343,13 @@ def _overlay_pdf_with_annotations(src, dest, output):
 
 
 def generate(
-    *, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
 ):
     header_rows = [
         [
@@ -404,7 +413,7 @@ def generate(
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -482,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/lambda/generateReports/rssardjito/generic/id_gen_neg.py
+++ b/lambda/generateReports/rssardjito/generic/id_gen_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/ID_Genome Report_No Finding-GENERIC.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/generic/id_gen_pos.py
+++ b/lambda/generateReports/rssardjito/generic/id_gen_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -339,7 +342,15 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None):
+def generate(
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
+):
     header_rows = [
         [
             "Gen/ Transkrip",
@@ -402,7 +413,7 @@ def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, ver
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -480,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/lambda/generateReports/rssardjito/md/en_md_neg.py
+++ b/lambda/generateReports/rssardjito/md/en_md_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/EN_Genome Report_No Finding_MD.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/md/en_md_pos.py
+++ b/lambda/generateReports/rssardjito/md/en_md_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -339,7 +342,15 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None):
+def generate(
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
+):
     header_rows = [
         [
             "Gene/ Transcript",
@@ -402,7 +413,7 @@ def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, ver
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -480,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/lambda/generateReports/rssardjito/md/id_md_neg.py
+++ b/lambda/generateReports/rssardjito/md/id_md_neg.py
@@ -65,6 +65,7 @@ def _create_annotations(
     pii_dob,
     pii_gender,
     versions,
+    report_id,
     filename,
 ):
     _text_field_positions_page_1 = [
@@ -115,6 +116,9 @@ def _create_annotations(
         (_text_field_positions_page_3, _static_text_page_3),
         (_text_field_positions_page_4, _static_text_page_4),
     ]:
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(page_poses_tf):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -166,10 +170,14 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, versions=None):
+def generate(
+    *, pii_name=None, pii_dob=None, pii_gender=None, versions=None, report_id=None
+):
     module_dir = Path(__file__).parent
     output_file_name = f"/tmp/{uuid.uuid4()}.pdf"
-    _create_annotations(pii_name, pii_dob, pii_gender, versions, "/tmp/annotations.pdf")
+    _create_annotations(
+        pii_name, pii_dob, pii_gender, versions, report_id, "/tmp/annotations.pdf"
+    )
     _overlay_pdf_with_annotations(
         "/tmp/annotations.pdf",
         f"{module_dir}/ID_Genome Report_No Finding_MD.pdf",
@@ -199,6 +207,7 @@ if __name__ == "__main__":
             "polyphen2_version": "N/A",
             "omim_version": "N/A",
         },
+        "report_id": str(uuid.uuid4()),
     }
 
     generate(**data)

--- a/lambda/generateReports/rssardjito/md/id_md_pos.py
+++ b/lambda/generateReports/rssardjito/md/id_md_pos.py
@@ -16,7 +16,7 @@ from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 
 
-def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
+def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender, report_id):
     c = canvas.Canvas(filename, pagesize=letter)
     form = c.acroForm
     fields = [
@@ -68,6 +68,9 @@ def _write_header_footer(filename, pages, pii_name, pii_dob, pii_gender):
     )
 
     for page in range(pages):
+        x, y, fs, text = (5, 780, 12, report_id)
+        c.setFont("Helvetica", fs)
+        c.drawString(x, y, text)
         for n, pos in enumerate(fields):
             x, y, w, h, fs, text, flags = pos
             c.setFont("Helvetica", fs)
@@ -339,7 +342,15 @@ def _overlay_pdf_with_annotations(src, dest, output):
         writer.write(f)
 
 
-def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, versions=None):
+def generate(
+    *,
+    pii_name=None,
+    pii_dob=None,
+    pii_gender=None,
+    variants=None,
+    versions=None,
+    report_id=None,
+):
     header_rows = [
         [
             "Gen/ Transkrip",
@@ -402,7 +413,7 @@ def generate(*, pii_name=None, pii_dob=None, pii_gender=None, variants=None, ver
     total_pages = len(pdf_table.pages) + len(pdf_rest.pages)
 
     _write_header_footer(
-        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender
+        output_pdf_annotations, total_pages, pii_name, pii_dob, pii_gender, report_id
     )
 
     footer_pagenum_annotations = PdfReader(output_pdf_annotations)
@@ -480,4 +491,4 @@ if __name__ == "__main__":
         "omim_version": "N/A",
     }
 
-    generate(variants=data, **pii_data, versions=versions)
+    generate(variants=data, **pii_data, versions=versions, report_id=str(uuid.uuid4()))

--- a/main.tf
+++ b/main.tf
@@ -799,19 +799,25 @@ module "lambda-getProjects" {
 module "lambda-generateReports" {
   source = "terraform-aws-modules/lambda/aws"
 
-  function_name = "sbeacon-backend-generateReports"
-  description   = "Backend function to generate reports."
-  runtime       = "python3.12"
-  handler       = "lambda_function.lambda_handler"
-  memory_size   = 512
-  timeout       = 60
-  source_path   = "${path.module}/lambda/generateReports"
+  function_name          = "sbeacon-backend-generateReports"
+  description            = "Backend function to generate reports."
+  runtime                = "python3.12"
+  handler                = "lambda_function.lambda_handler"
+  memory_size            = 512
+  timeout                = 60
+  source_path            = "${path.module}/lambda/generateReports"
+  attach_policy_jsons    = true
+  number_of_policy_jsons = 1
+  tags                   = var.common-tags
 
   environment_variables = {
     DYNAMO_SVEP_REFERENCES_TABLE = var.svep-references-table-name
+    DPORTAL_BUCKET               = aws_s3_bucket.dataportal-bucket.bucket
   }
 
-  tags = var.common-tags
+  policy_jsons = [
+    data.aws_iam_policy_document.lambda-generateReports.json,
+  ]
 }
 
 #


### PR DESCRIPTION
- Updated the report generation functions across multiple modules to accept and display a unique report ID.
- Changed the PDF annotation creation to include the report ID in the header/footer of generated reports.
- Modified the lambda function to pass the report ID through the event payload.
- Added S3 storage functionality to save report metadata, including the report ID.
- Updated Terraform configuration to include necessary environment variables for S3 bucket access.