### PR TITLE
Fix: Clean up stale symlinks before creating new ones

### DIFF
--- a/lambda/generateReports/igng/create_symlinks.sh
+++ b/lambda/generateReports/igng/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../report_templates/igng/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rscm/create_symlinks.sh
+++ b/lambda/generateReports/rscm/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../report_templates/rscm/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rsjpd/create_symlinks.sh
+++ b/lambda/generateReports/rsjpd/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../report_templates/rsjpd/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rspon/create_symlinks.sh
+++ b/lambda/generateReports/rspon/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../report_templates/rspon/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rssardjito/crd/create_symlinks.sh
+++ b/lambda/generateReports/rssardjito/crd/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../../report_templates/rssardjito/crd/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rssardjito/generic/create_symlinks.sh
+++ b/lambda/generateReports/rssardjito/generic/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../../report_templates/rssardjito/gen/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done

--- a/lambda/generateReports/rssardjito/md/create_symlinks.sh
+++ b/lambda/generateReports/rssardjito/md/create_symlinks.sh
@@ -1,3 +1,5 @@
+rm -f *.pdf
+
 for file in ../../../../../report_templates/rssardjito/md/*.pdf; do
   ln -s "$file" "$(basename "$file")"
 done


### PR DESCRIPTION
## Fix: Clean up stale symlinks before creating new ones

### Problem
Script was failing with `FileNotFoundError` when files were deleted from the git submodule but symlinks still existed in the destination folder, pointing to non-existent files.

**Error Example:**
```
FileNotFoundError: [Errno 2] No such file or directory:
'/atlantis/data/repos/.../EN_Genome Report_No Finding-GENERIC.pdf'

### Solution
Modified `create_symlink` script to:
1. **Clear all existing PDF files first** using `rm -f *.pdf`
2. **Then create fresh symlinks** from the source directory

This ensures that:
- Stale/broken symlinks are removed before creating new ones
- No orphaned symlinks remain when files are deleted from the submodule
- Clean state on every symlink recreation